### PR TITLE
FH-2541 - update license date

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2016 Red Hat, Inc.
+   Copyright 2017 Red Hat, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Motivation
License out of date

## Result
Updated date in the license, no license headers were found in source

## Jira
https://issues.jboss.org/browse/FH-2541